### PR TITLE
add cache refresh to fix compute profile creation bug

### DIFF
--- a/sat/roles/satellite_post/tasks/ensure_compute_profile.yml
+++ b/sat/roles/satellite_post/tasks/ensure_compute_profile.yml
@@ -9,7 +9,30 @@
     state: "{{ cpr.state | default(omit) }}"
     compute_attributes: "{{ cpr.compute_attributes | default(omit) }}"
 
+- name: "Get the compute resource id"
+  redhat.satellite.compute_resource:
+    username: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "{{ satellite_url }}"
+    validate_certs: "{{ satellite_validate_certs }}"
+    name: "{{ cpr.compute_attributes[0].compute_resource }}"
+    state: "present"
+  register: result
+
+- ansible.builtin.set_fact:
+    cr_id: "{{ result.entity.compute_resources[0].id }}"
+
 # you can change the name of the compute profile by simply passing name and updated_name
-- name: "Wait on API background refresh"
-  ansible.builtin.wait_for:
-    timeout: 15
+- name: "Force refresh of Compute Resource API cache"
+  ansible.builtin.uri:
+    url: "{{ satellite_url }}/api/compute_resources/{{ cr_id }}-{{ cpr.compute_attributes[0].compute_resource }}/refresh_cache"
+    method: "PUT"
+    body_format: "json"
+    user: "{{ satellite_admin_username }}"
+    password: "{{ satellite_admin_password }}"
+    force_basic_auth: true
+    validate_certs: "{{ satellite_validate_certs }}"
+  register: refresh_result
+
+- debug:
+    var: refresh_result.json.message    

--- a/sat/vars/satellite_provisioning_vars_vmware.yml
+++ b/sat/vars/satellite_provisioning_vars_vmware.yml
@@ -74,7 +74,7 @@ compute_profiles_mandatory:
           corespersocket: 1
           memory_mb: 4096
           cluster: "NUCLab"
-          resource_pool: "Resources"
+          # resource_pool: "Resources"
           path: "/Datacenters/example.ca/vm"
           guest_id: "rhel8_64Guest"
           hardware_version: "Default"
@@ -104,11 +104,11 @@ compute_profiles_mandatory:
     compute_attributes:
       - compute_resource: "VMware_Lab"
         vm_attrs:
-          cpus: 2
+          cpus: 1
           corespersocket: 1
           memory_mb: 8192
           cluster: "NUCLab"
-          resource_pool: "Resources"
+          # resource_pool: "Resources"
           path: "/Datacenters/example.ca/vm"
           guest_id: "rhel8_64Guest"
           hardware_version: "Default"
@@ -138,11 +138,11 @@ compute_profiles_mandatory:
     compute_attributes:
       - compute_resource: "VMware_Lab"
         vm_attrs:
-          cpus: 4
+          cpus: 2
           corespersocket: 1
-          memory_mb: 8192
+          memory_mb: 16364
           cluster: "NUCLab"
-          resource_pool: "Resources"
+          # resource_pool: "Resources"
           path: "/Datacenters/example.ca/vm"
           guest_id: "rhel8_64Guest"
           hardware_version: "Default"

--- a/sat/vars/satellite_vars.yml
+++ b/sat/vars/satellite_vars.yml
@@ -1,5 +1,5 @@
 ---
-satellite_fqdn: "{{ ansible_fqdn }}"
+satellite_fqdn: "{{ groups['sat_primary'][0] }}"
 satellite_domain: "{{ ansible_domain }}"
 
 satellite_url: "https://{{ satellite_fqdn }}"


### PR DESCRIPTION
compute profile creation failing against satellite with 500 return code. Removed the timeout wait and forced a cache refresh via the API. Need to get cache fresh added to FAM.